### PR TITLE
Fallback to code for BitBag media item if name is empty

### DIFF
--- a/lib/ContentBrowser/Item/Media/Item.php
+++ b/lib/ContentBrowser/Item/Media/Item.php
@@ -23,7 +23,7 @@ final class Item implements ItemInterface, MediaInterface
 
     public function getName(): string
     {
-        return (string) ($this->media->getName() ?? $this->media->getCode());
+        return $this->media->getName() ?? $this->media->getCode();
     }
 
     public function isVisible(): bool

--- a/lib/ContentBrowser/Item/Media/Item.php
+++ b/lib/ContentBrowser/Item/Media/Item.php
@@ -23,7 +23,7 @@ final class Item implements ItemInterface, MediaInterface
 
     public function getName(): string
     {
-        return $this->media->getName() ?? $this->media->getCode();
+        return $this->media->getName() ?? $this->media->getCode() ?? '';
     }
 
     public function isVisible(): bool

--- a/lib/ContentBrowser/Item/Media/Item.php
+++ b/lib/ContentBrowser/Item/Media/Item.php
@@ -23,7 +23,7 @@ final class Item implements ItemInterface, MediaInterface
 
     public function getName(): string
     {
-        return (string) $this->media->getName();
+        return (string) ($this->media->getName() ?? $this->media->getCode());
     }
 
     public function isVisible(): bool

--- a/lib/Item/ValueConverter/MediaValueConverter.php
+++ b/lib/Item/ValueConverter/MediaValueConverter.php
@@ -34,7 +34,7 @@ final class MediaValueConverter implements ValueConverterInterface
 
     public function getName(object $object): string
     {
-        return (string) ($object->getName() ?? $object->getCode());
+        return $object->getName() ?? $object->getCode();
     }
 
     public function getIsVisible(object $object): bool

--- a/lib/Item/ValueConverter/MediaValueConverter.php
+++ b/lib/Item/ValueConverter/MediaValueConverter.php
@@ -34,7 +34,7 @@ final class MediaValueConverter implements ValueConverterInterface
 
     public function getName(object $object): string
     {
-        return $object->getName() ?? $object->getCode();
+        return $object->getName() ?? $object->getCode() ?? '';
     }
 
     public function getIsVisible(object $object): bool

--- a/lib/Item/ValueConverter/MediaValueConverter.php
+++ b/lib/Item/ValueConverter/MediaValueConverter.php
@@ -34,7 +34,7 @@ final class MediaValueConverter implements ValueConverterInterface
 
     public function getName(object $object): string
     {
-        return (string) $object->getName();
+        return (string) ($object->getName() ?? $object->getCode());
     }
 
     public function getIsVisible(object $object): bool

--- a/tests/lib/ContentBrowser/Item/Media/ItemTest.php
+++ b/tests/lib/ContentBrowser/Item/Media/ItemTest.php
@@ -54,6 +54,16 @@ final class ItemTest extends TestCase
     }
 
     /**
+     * @covers \Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Media\Item::getName
+     */
+    public function testGetNameWithEmptyNameAndCode(): void
+    {
+        $media = new Media(42);
+
+        self::assertSame('', $media->getName());
+    }
+
+    /**
      * @covers \Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Media\Item::isVisible
      */
     public function testIsVisible(): void

--- a/tests/lib/ContentBrowser/Item/Media/ItemTest.php
+++ b/tests/lib/ContentBrowser/Item/Media/ItemTest.php
@@ -48,6 +48,8 @@ final class ItemTest extends TestCase
     public function testGetNameWithEmptyName(): void
     {
         $media = new Media(42, 'logo');
+        $this->media->setCurrentLocale('en');
+        $this->media->setFallbackLocale('en');
 
         self::assertSame('logo', $media->getName());
     }
@@ -58,6 +60,8 @@ final class ItemTest extends TestCase
     public function testGetNameWithEmptyNameAndCode(): void
     {
         $media = new Media(42);
+        $this->media->setCurrentLocale('en');
+        $this->media->setFallbackLocale('en');
 
         self::assertSame('', $media->getName());
     }

--- a/tests/lib/ContentBrowser/Item/Media/ItemTest.php
+++ b/tests/lib/ContentBrowser/Item/Media/ItemTest.php
@@ -42,6 +42,13 @@ final class ItemTest extends TestCase
         self::assertSame('Logo', $this->item->getName());
     }
 
+    public function testGetNameWithEmptyName(): void
+    {
+        $media = new Media(42, 'logo');
+
+        self::assertSame('logo', $media->getName());
+    }
+
     /**
      * @covers \Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Media\Item::isVisible
      */

--- a/tests/lib/ContentBrowser/Item/Media/ItemTest.php
+++ b/tests/lib/ContentBrowser/Item/Media/ItemTest.php
@@ -42,7 +42,6 @@ final class ItemTest extends TestCase
         self::assertSame('Logo', $this->item->getName());
     }
 
-
     /**
      * @covers \Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Media\Item::getName
      */

--- a/tests/lib/ContentBrowser/Item/Media/ItemTest.php
+++ b/tests/lib/ContentBrowser/Item/Media/ItemTest.php
@@ -42,6 +42,10 @@ final class ItemTest extends TestCase
         self::assertSame('Logo', $this->item->getName());
     }
 
+
+    /**
+     * @covers \Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Media\Item::getName
+     */
     public function testGetNameWithEmptyName(): void
     {
         $media = new Media(42, 'logo');

--- a/tests/lib/ContentBrowser/Item/Media/ItemTest.php
+++ b/tests/lib/ContentBrowser/Item/Media/ItemTest.php
@@ -48,10 +48,11 @@ final class ItemTest extends TestCase
     public function testGetNameWithEmptyName(): void
     {
         $media = new Media(42, 'logo');
-        $this->media->setCurrentLocale('en');
-        $this->media->setFallbackLocale('en');
+        $media->setCurrentLocale('en');
+        $media->setFallbackLocale('en');
+        $item = new Item($media);
 
-        self::assertSame('logo', $media->getName());
+        self::assertSame('logo', $item->getName());
     }
 
     /**
@@ -60,10 +61,11 @@ final class ItemTest extends TestCase
     public function testGetNameWithEmptyNameAndCode(): void
     {
         $media = new Media(42);
-        $this->media->setCurrentLocale('en');
-        $this->media->setFallbackLocale('en');
+        $media->setCurrentLocale('en');
+        $media->setFallbackLocale('en');
+        $item = new Item($media);
 
-        self::assertSame('', $media->getName());
+        self::assertSame('', $item->getName());
     }
 
     /**

--- a/tests/lib/Item/Stubs/Media.php
+++ b/tests/lib/Item/Stubs/Media.php
@@ -10,8 +10,8 @@ final class Media extends BaseMedia
 {
     public function __construct(
         int $id,
-        string $code,
-        string $name,
+        ?string $code = null,
+        ?string $name = null,
         string $type = 'file',
         bool $enabled = true
     ) {

--- a/tests/lib/Item/ValueConverter/MediaValueConverterTest.php
+++ b/tests/lib/Item/ValueConverter/MediaValueConverterTest.php
@@ -78,7 +78,13 @@ final class MediaValueConverterTest extends TestCase
                 new MediaStub(42, 'logo-image', 'Logo image'),
             ),
         );
+    }
 
+    /**
+     * @covers \Netgen\Layouts\Sylius\BitBag\Item\ValueConverter\MediaValueConverter::getName
+     */
+    public function testGetNameWithEmptyName(): void
+    {
         self::assertSame(
             'logo-image',
             $this->valueConverter->getName(

--- a/tests/lib/Item/ValueConverter/MediaValueConverterTest.php
+++ b/tests/lib/Item/ValueConverter/MediaValueConverterTest.php
@@ -94,6 +94,19 @@ final class MediaValueConverterTest extends TestCase
     }
 
     /**
+     * @covers \Netgen\Layouts\Sylius\BitBag\Item\ValueConverter\MediaValueConverter::getName
+     */
+    public function testGetNameWithEmptyNameAndCode(): void
+    {
+        self::assertSame(
+            '',
+            $this->valueConverter->getName(
+                new MediaStub(42),
+            ),
+        );
+    }
+
+    /**
      * @covers \Netgen\Layouts\Sylius\BitBag\Item\ValueConverter\MediaValueConverter::getIsVisible
      */
     public function testGetIsVisible(): void

--- a/tests/lib/Item/ValueConverter/MediaValueConverterTest.php
+++ b/tests/lib/Item/ValueConverter/MediaValueConverterTest.php
@@ -78,6 +78,13 @@ final class MediaValueConverterTest extends TestCase
                 new MediaStub(42, 'logo-image', 'Logo image'),
             ),
         );
+
+        self::assertSame(
+            'logo-image',
+            $this->valueConverter->getName(
+                new MediaStub(42, 'logo-image'),
+            ),
+        );
     }
 
     /**

--- a/tests/lib/Stubs/Media.php
+++ b/tests/lib/Stubs/Media.php
@@ -8,7 +8,7 @@ use BitBag\SyliusCmsPlugin\Entity\Media as BaseMedia;
 
 final class Media extends BaseMedia
 {
-    public function __construct(int $id, string $code)
+    public function __construct(int $id, ?string $code = null)
     {
         parent::__construct();
 


### PR DESCRIPTION
Name is a non-required field in BitBag for media type so we should fallback to code which is always present.