### PR TITLE
Fix offset in Backends and QueryHandlers

### DIFF
--- a/lib/Collection/QueryType/Handler/BlockHandler.php
+++ b/lib/Collection/QueryType/Handler/BlockHandler.php
@@ -17,6 +17,8 @@ use Netgen\Layouts\Sylius\BitBag\Repository\BlockRepositoryInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+use function max;
+
 use const PHP_INT_MAX;
 
 final class BlockHandler implements QueryTypeHandlerInterface

--- a/lib/Collection/QueryType/Handler/BlockHandler.php
+++ b/lib/Collection/QueryType/Handler/BlockHandler.php
@@ -93,7 +93,7 @@ final class BlockHandler implements QueryTypeHandlerInterface
         $this->addSyliusChannelFilterCriterion($query, $queryBuilder);
         $this->addBitBagEnabledCriterion($queryBuilder);
 
-        return (int)$queryBuilder
+        return (int) $queryBuilder
             ->select('count(o.id)')
             ->getQuery()
             ->getSingleScalarResult();

--- a/lib/Collection/QueryType/Handler/BlockHandler.php
+++ b/lib/Collection/QueryType/Handler/BlockHandler.php
@@ -66,12 +66,13 @@ final class BlockHandler implements QueryTypeHandlerInterface
 
         $paginator = $this->blockRepository->createFilterPaginator($queryBuilder);
 
-        $limit = $limit ?? PHP_INT_MAX;
+        $limit = $limit === null ? PHP_INT_MAX : max(0, $limit);
+        $offset = max(0, $offset);
 
         $paginator->setMaxPerPage($limit);
         $paginator->setCurrentPage((int) ($offset / $limit) + 1);
 
-        return $paginator->getCurrentPageResults();
+        return $paginator->getAdapter()->getSlice($offset, $limit);
     }
 
     public function getCount(Query $query): int

--- a/lib/Collection/QueryType/Handler/BlockHandler.php
+++ b/lib/Collection/QueryType/Handler/BlockHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Netgen\Layouts\Sylius\BitBag\Collection\QueryType\Handler;
 
-use BitBag\SyliusCmsPlugin\Entity\BlockInterface;
 use Netgen\Layouts\API\Values\Collection\Query;
 use Netgen\Layouts\Collection\QueryType\QueryTypeHandlerInterface;
 use Netgen\Layouts\Parameters\ParameterBuilderInterface;
@@ -31,7 +30,9 @@ final class BlockHandler implements QueryTypeHandlerInterface
     use SyliusProductTrait;
     use SyliusTaxonTrait;
 
-    /** @var array<string, string> */
+    /**
+     * @var array<string, string>
+     */
     private array $sortingOptions = [
         'Name' => 'translation.name',
         'Code' => 'code',
@@ -52,10 +53,7 @@ final class BlockHandler implements QueryTypeHandlerInterface
         $this->buildBitBagSortingParameters($builder, $this->sortingOptions);
     }
 
-    /**
-     * @return BlockInterface[]
-     */
-    public function getValues(Query $query, int $offset = 0, ?int $limit = null): array
+    public function getValues(Query $query, int $offset = 0, ?int $limit = null): iterable
     {
         $queryBuilder = $this->blockRepository->createListQueryBuilder(
             $this->localeContext->getLocaleCode(),

--- a/lib/Collection/QueryType/Handler/FrequentlyAskedQuestionHandler.php
+++ b/lib/Collection/QueryType/Handler/FrequentlyAskedQuestionHandler.php
@@ -74,7 +74,7 @@ final class FrequentlyAskedQuestionHandler implements QueryTypeHandlerInterface
         $this->addSyliusChannelFilterCriterion($query, $queryBuilder);
         $this->addBitBagEnabledCriterion($queryBuilder);
 
-        return (int)$queryBuilder
+        return (int) $queryBuilder
             ->select('count(o.id)')
             ->getQuery()
             ->getSingleScalarResult();

--- a/lib/Collection/QueryType/Handler/FrequentlyAskedQuestionHandler.php
+++ b/lib/Collection/QueryType/Handler/FrequentlyAskedQuestionHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Netgen\Layouts\Sylius\BitBag\Collection\QueryType\Handler;
 
-use BitBag\SyliusCmsPlugin\Entity\FrequentlyAskedQuestionInterface;
 use Netgen\Layouts\API\Values\Collection\Query;
 use Netgen\Layouts\Collection\QueryType\QueryTypeHandlerInterface;
 use Netgen\Layouts\Parameters\ParameterBuilderInterface;
@@ -24,7 +23,9 @@ final class FrequentlyAskedQuestionHandler implements QueryTypeHandlerInterface
     use BitBagSortingTrait;
     use SyliusChannelFilterTrait;
 
-    /** @var array<string, string> */
+    /**
+     * @var array<string, string>
+     */
     private array $sortingOptions = [
         'Position' => 'position',
         'Question' => 'translation.question',
@@ -43,10 +44,7 @@ final class FrequentlyAskedQuestionHandler implements QueryTypeHandlerInterface
         $this->buildBitBagSortingParameters($builder, $this->sortingOptions);
     }
 
-    /**
-     * @return FrequentlyAskedQuestionInterface[]
-     */
-    public function getValues(Query $query, int $offset = 0, ?int $limit = null): array
+    public function getValues(Query $query, int $offset = 0, ?int $limit = null): iterable
     {
         $queryBuilder = $this->frequentlyAskedQuestionRepository->createListQueryBuilder(
             $this->localeContext->getLocaleCode(),

--- a/lib/Collection/QueryType/Handler/FrequentlyAskedQuestionHandler.php
+++ b/lib/Collection/QueryType/Handler/FrequentlyAskedQuestionHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netgen\Layouts\Sylius\BitBag\Collection\QueryType\Handler;
 
+use BitBag\SyliusCmsPlugin\Entity\FrequentlyAskedQuestionInterface;
 use Netgen\Layouts\API\Values\Collection\Query;
 use Netgen\Layouts\Collection\QueryType\QueryTypeHandlerInterface;
 use Netgen\Layouts\Parameters\ParameterBuilderInterface;
@@ -26,8 +27,8 @@ final class FrequentlyAskedQuestionHandler implements QueryTypeHandlerInterface
     /** @var array<string, string> */
     private array $sortingOptions = [
         'Position' => 'position',
-        'Question' => 'translations.question',
-        'Answer' => 'translations.answer',
+        'Question' => 'translation.question',
+        'Answer' => 'translation.answer',
         'Code' => 'code',
     ];
 
@@ -42,7 +43,10 @@ final class FrequentlyAskedQuestionHandler implements QueryTypeHandlerInterface
         $this->buildBitBagSortingParameters($builder, $this->sortingOptions);
     }
 
-    public function getValues(Query $query, int $offset = 0, ?int $limit = null): iterable
+    /**
+     * @return FrequentlyAskedQuestionInterface[]
+     */
+    public function getValues(Query $query, int $offset = 0, ?int $limit = null): array
     {
         $queryBuilder = $this->frequentlyAskedQuestionRepository->createListQueryBuilder(
             $this->localeContext->getLocaleCode(),
@@ -52,15 +56,13 @@ final class FrequentlyAskedQuestionHandler implements QueryTypeHandlerInterface
         $this->addBitBagEnabledCriterion($queryBuilder);
         $this->addBitBagSortingClause($query, $queryBuilder);
 
-        $paginator = $this->frequentlyAskedQuestionRepository->createFilterPaginator($queryBuilder);
-
         $limit = $limit === null ? PHP_INT_MAX : max(0, $limit);
         $offset = max(0, $offset);
 
-        $paginator->setMaxPerPage($limit);
-        $paginator->setCurrentPage((int) ($offset / $limit) + 1);
-
-        return $paginator->getAdapter()->getSlice($offset, $limit);
+        return $queryBuilder->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
     }
 
     public function getCount(Query $query): int
@@ -72,9 +74,10 @@ final class FrequentlyAskedQuestionHandler implements QueryTypeHandlerInterface
         $this->addSyliusChannelFilterCriterion($query, $queryBuilder);
         $this->addBitBagEnabledCriterion($queryBuilder);
 
-        $paginator = $this->frequentlyAskedQuestionRepository->createFilterPaginator($queryBuilder);
-
-        return $paginator->getNbResults();
+        return (int)$queryBuilder
+            ->select('count(o.id)')
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 
     public function isContextual(Query $query): bool

--- a/lib/Collection/QueryType/Handler/FrequentlyAskedQuestionHandler.php
+++ b/lib/Collection/QueryType/Handler/FrequentlyAskedQuestionHandler.php
@@ -13,6 +13,8 @@ use Netgen\Layouts\Sylius\BitBag\Collection\QueryType\Handler\Traits\SyliusChann
 use Netgen\Layouts\Sylius\BitBag\Repository\FrequentlyAskedQuestionRepositoryInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 
+use function max;
+
 use const PHP_INT_MAX;
 
 final class FrequentlyAskedQuestionHandler implements QueryTypeHandlerInterface

--- a/lib/Collection/QueryType/Handler/FrequentlyAskedQuestionHandler.php
+++ b/lib/Collection/QueryType/Handler/FrequentlyAskedQuestionHandler.php
@@ -52,12 +52,13 @@ final class FrequentlyAskedQuestionHandler implements QueryTypeHandlerInterface
 
         $paginator = $this->frequentlyAskedQuestionRepository->createFilterPaginator($queryBuilder);
 
-        $limit = $limit ?? PHP_INT_MAX;
+        $limit = $limit === null ? PHP_INT_MAX : max(0, $limit);
+        $offset = max(0, $offset);
 
         $paginator->setMaxPerPage($limit);
         $paginator->setCurrentPage((int) ($offset / $limit) + 1);
 
-        return $paginator->getCurrentPageResults();
+        return $paginator->getAdapter()->getSlice($offset, $limit);
     }
 
     public function getCount(Query $query): int

--- a/lib/Collection/QueryType/Handler/MediaHandler.php
+++ b/lib/Collection/QueryType/Handler/MediaHandler.php
@@ -62,12 +62,13 @@ final class MediaHandler implements QueryTypeHandlerInterface
 
         $paginator = $this->mediaRepository->createFilterPaginator($queryBuilder);
 
-        $limit = $limit ?? PHP_INT_MAX;
+        $limit = $limit === null ? PHP_INT_MAX : max(0, $limit);
+        $offset = max(0, $offset);
 
         $paginator->setMaxPerPage($limit);
         $paginator->setCurrentPage((int) ($offset / $limit) + 1);
 
-        return $paginator->getCurrentPageResults();
+        return $paginator->getAdapter()->getSlice($offset, $limit);
     }
 
     public function getCount(Query $query): int

--- a/lib/Collection/QueryType/Handler/MediaHandler.php
+++ b/lib/Collection/QueryType/Handler/MediaHandler.php
@@ -16,6 +16,8 @@ use Netgen\Layouts\Sylius\BitBag\Repository\MediaRepositoryInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+use function max;
+
 use const PHP_INT_MAX;
 
 final class MediaHandler implements QueryTypeHandlerInterface

--- a/lib/Collection/QueryType/Handler/MediaHandler.php
+++ b/lib/Collection/QueryType/Handler/MediaHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Netgen\Layouts\Sylius\BitBag\Collection\QueryType\Handler;
 
-use BitBag\SyliusCmsPlugin\Entity\MediaInterface;
 use Netgen\Layouts\API\Values\Collection\Query;
 use Netgen\Layouts\Collection\QueryType\QueryTypeHandlerInterface;
 use Netgen\Layouts\Parameters\ParameterBuilderInterface;
@@ -29,7 +28,9 @@ final class MediaHandler implements QueryTypeHandlerInterface
     use SyliusChannelFilterTrait;
     use SyliusProductTrait;
 
-    /** @var array<string, string> */
+    /**
+     * @var array<string, string>
+     */
     private array $sortingOptions = [
         'Name' => 'translation.name',
         'Code' => 'code',
@@ -49,10 +50,7 @@ final class MediaHandler implements QueryTypeHandlerInterface
         $this->buildBitBagSortingParameters($builder, $this->sortingOptions);
     }
 
-    /**
-     * @return MediaInterface[]
-     */
-    public function getValues(Query $query, int $offset = 0, ?int $limit = null): array
+    public function getValues(Query $query, int $offset = 0, ?int $limit = null): iterable
     {
         $queryBuilder = $this->mediaRepository->createListQueryBuilder(
             $this->localeContext->getLocaleCode(),

--- a/lib/Collection/QueryType/Handler/MediaHandler.php
+++ b/lib/Collection/QueryType/Handler/MediaHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netgen\Layouts\Sylius\BitBag\Collection\QueryType\Handler;
 
+use BitBag\SyliusCmsPlugin\Entity\MediaInterface;
 use Netgen\Layouts\API\Values\Collection\Query;
 use Netgen\Layouts\Collection\QueryType\QueryTypeHandlerInterface;
 use Netgen\Layouts\Parameters\ParameterBuilderInterface;
@@ -30,7 +31,7 @@ final class MediaHandler implements QueryTypeHandlerInterface
 
     /** @var array<string, string> */
     private array $sortingOptions = [
-        'Name' => 'translations.name',
+        'Name' => 'translation.name',
         'Code' => 'code',
     ];
 
@@ -48,7 +49,10 @@ final class MediaHandler implements QueryTypeHandlerInterface
         $this->buildBitBagSortingParameters($builder, $this->sortingOptions);
     }
 
-    public function getValues(Query $query, int $offset = 0, ?int $limit = null): iterable
+    /**
+     * @return MediaInterface[]
+     */
+    public function getValues(Query $query, int $offset = 0, ?int $limit = null): array
     {
         $queryBuilder = $this->mediaRepository->createListQueryBuilder(
             $this->localeContext->getLocaleCode(),
@@ -62,15 +66,13 @@ final class MediaHandler implements QueryTypeHandlerInterface
         $this->addBitBagEnabledCriterion($queryBuilder);
         $this->addBitBagSortingClause($query, $queryBuilder);
 
-        $paginator = $this->mediaRepository->createFilterPaginator($queryBuilder);
-
         $limit = $limit === null ? PHP_INT_MAX : max(0, $limit);
         $offset = max(0, $offset);
 
-        $paginator->setMaxPerPage($limit);
-        $paginator->setCurrentPage((int) ($offset / $limit) + 1);
-
-        return $paginator->getAdapter()->getSlice($offset, $limit);
+        return $queryBuilder->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
     }
 
     public function getCount(Query $query): int
@@ -86,9 +88,10 @@ final class MediaHandler implements QueryTypeHandlerInterface
         $this->addSyliusChannelFilterCriterion($query, $queryBuilder);
         $this->addBitBagEnabledCriterion($queryBuilder);
 
-        $paginator = $this->mediaRepository->createFilterPaginator($queryBuilder);
-
-        return $paginator->getNbResults();
+        return (int)$queryBuilder
+            ->select('count(o.id)')
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 
     public function isContextual(Query $query): bool

--- a/lib/Collection/QueryType/Handler/MediaHandler.php
+++ b/lib/Collection/QueryType/Handler/MediaHandler.php
@@ -88,7 +88,7 @@ final class MediaHandler implements QueryTypeHandlerInterface
         $this->addSyliusChannelFilterCriterion($query, $queryBuilder);
         $this->addBitBagEnabledCriterion($queryBuilder);
 
-        return (int)$queryBuilder
+        return (int) $queryBuilder
             ->select('count(o.id)')
             ->getQuery()
             ->getSingleScalarResult();

--- a/lib/Collection/QueryType/Handler/PageHandler.php
+++ b/lib/Collection/QueryType/Handler/PageHandler.php
@@ -16,6 +16,8 @@ use Netgen\Layouts\Sylius\BitBag\Repository\PageRepositoryInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+use function max;
+
 use const PHP_INT_MAX;
 
 final class PageHandler implements QueryTypeHandlerInterface

--- a/lib/Collection/QueryType/Handler/PageHandler.php
+++ b/lib/Collection/QueryType/Handler/PageHandler.php
@@ -65,12 +65,13 @@ final class PageHandler implements QueryTypeHandlerInterface
 
         $paginator = $this->pageRepository->createFilterPaginator($queryBuilder);
 
-        $limit = $limit ?? PHP_INT_MAX;
+        $limit = $limit === null ? PHP_INT_MAX : max(0, $limit);
+        $offset = max(0, $offset);
 
         $paginator->setMaxPerPage($limit);
         $paginator->setCurrentPage((int) ($offset / $limit) + 1);
 
-        return $paginator->getCurrentPageResults();
+        return $paginator->getAdapter()->getSlice($offset, $limit);
     }
 
     public function getCount(Query $query): int

--- a/lib/Collection/QueryType/Handler/PageHandler.php
+++ b/lib/Collection/QueryType/Handler/PageHandler.php
@@ -91,7 +91,7 @@ final class PageHandler implements QueryTypeHandlerInterface
         $this->addSyliusChannelFilterCriterion($query, $queryBuilder);
         $this->addBitBagEnabledCriterion($queryBuilder);
 
-        return (int)$queryBuilder
+        return (int) $queryBuilder
             ->select('count(o.id)')
             ->getQuery()
             ->getSingleScalarResult();

--- a/lib/Collection/QueryType/Handler/PageHandler.php
+++ b/lib/Collection/QueryType/Handler/PageHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Netgen\Layouts\Sylius\BitBag\Collection\QueryType\Handler;
 
-use BitBag\SyliusCmsPlugin\Entity\PageInterface;
 use Netgen\Layouts\API\Values\Collection\Query;
 use Netgen\Layouts\Collection\QueryType\QueryTypeHandlerInterface;
 use Netgen\Layouts\Parameters\ParameterBuilderInterface;
@@ -29,7 +28,9 @@ final class PageHandler implements QueryTypeHandlerInterface
     use SyliusChannelFilterTrait;
     use SyliusProductTrait;
 
-    /** @var array<string, string> */
+    /**
+     * @var array<string, string>
+     */
     private array $sortingOptions = [
         'Name' => 'translation.name',
         'Code' => 'code',
@@ -52,10 +53,7 @@ final class PageHandler implements QueryTypeHandlerInterface
         $this->buildBitBagSortingParameters($builder, $this->sortingOptions);
     }
 
-    /**
-     * @return PageInterface[]
-     */
-    public function getValues(Query $query, int $offset = 0, ?int $limit = null): array
+    public function getValues(Query $query, int $offset = 0, ?int $limit = null): iterable
     {
         $queryBuilder = $this->pageRepository->createListQueryBuilder(
             $this->localeContext->getLocaleCode(),

--- a/lib/Collection/QueryType/Handler/SectionHandler.php
+++ b/lib/Collection/QueryType/Handler/SectionHandler.php
@@ -12,6 +12,8 @@ use Netgen\Layouts\Sylius\BitBag\Collection\QueryType\Handler\Traits\SyliusChann
 use Netgen\Layouts\Sylius\BitBag\Repository\SectionRepositoryInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 
+use function max;
+
 use const PHP_INT_MAX;
 
 final class SectionHandler implements QueryTypeHandlerInterface

--- a/lib/Collection/QueryType/Handler/SectionHandler.php
+++ b/lib/Collection/QueryType/Handler/SectionHandler.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Netgen\Layouts\Sylius\BitBag\Collection\QueryType\Handler;
 
+use BitBag\SyliusCmsPlugin\Entity\SectionInterface;
 use Netgen\Layouts\API\Values\Collection\Query;
 use Netgen\Layouts\Collection\QueryType\QueryTypeHandlerInterface;
 use Netgen\Layouts\Parameters\ParameterBuilderInterface;
 use Netgen\Layouts\Sylius\BitBag\Collection\QueryType\Handler\Traits\BitBagSortingTrait;
-use Netgen\Layouts\Sylius\BitBag\Collection\QueryType\Handler\Traits\SyliusChannelFilterTrait;
 use Netgen\Layouts\Sylius\BitBag\Repository\SectionRepositoryInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 
@@ -19,11 +19,10 @@ use const PHP_INT_MAX;
 final class SectionHandler implements QueryTypeHandlerInterface
 {
     use BitBagSortingTrait;
-    use SyliusChannelFilterTrait;
 
     /** @var array<string, string> */
     private array $sortingOptions = [
-        'Name' => 'translations.name',
+        'Name' => 'translation.name',
         'Code' => 'code',
     ];
 
@@ -34,28 +33,27 @@ final class SectionHandler implements QueryTypeHandlerInterface
 
     public function buildParameters(ParameterBuilderInterface $builder): void
     {
-        $this->buildSyliusChannelFilterParameters($builder);
         $this->buildBitBagSortingParameters($builder, $this->sortingOptions);
     }
 
-    public function getValues(Query $query, int $offset = 0, ?int $limit = null): iterable
+    /**
+     * @return SectionInterface[]
+     */
+    public function getValues(Query $query, int $offset = 0, ?int $limit = null): array
     {
         $queryBuilder = $this->sectionRepository->createListQueryBuilder(
             $this->localeContext->getLocaleCode(),
         );
 
-        $this->addSyliusChannelFilterCriterion($query, $queryBuilder);
         $this->addBitBagSortingClause($query, $queryBuilder);
-
-        $paginator = $this->sectionRepository->createFilterPaginator($queryBuilder);
 
         $limit = $limit === null ? PHP_INT_MAX : max(0, $limit);
         $offset = max(0, $offset);
 
-        $paginator->setMaxPerPage($limit);
-        $paginator->setCurrentPage((int) ($offset / $limit) + 1);
-
-        return $paginator->getAdapter()->getSlice($offset, $limit);
+        return $queryBuilder->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
     }
 
     public function getCount(Query $query): int
@@ -64,11 +62,10 @@ final class SectionHandler implements QueryTypeHandlerInterface
             $this->localeContext->getLocaleCode(),
         );
 
-        $this->addSyliusChannelFilterCriterion($query, $queryBuilder);
-
-        $paginator = $this->sectionRepository->createFilterPaginator($queryBuilder);
-
-        return $paginator->getNbResults();
+        return (int)$queryBuilder
+            ->select('count(o.id)')
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 
     public function isContextual(Query $query): bool

--- a/lib/Collection/QueryType/Handler/SectionHandler.php
+++ b/lib/Collection/QueryType/Handler/SectionHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Netgen\Layouts\Sylius\BitBag\Collection\QueryType\Handler;
 
-use BitBag\SyliusCmsPlugin\Entity\SectionInterface;
 use Netgen\Layouts\API\Values\Collection\Query;
 use Netgen\Layouts\Collection\QueryType\QueryTypeHandlerInterface;
 use Netgen\Layouts\Parameters\ParameterBuilderInterface;
@@ -20,7 +19,9 @@ final class SectionHandler implements QueryTypeHandlerInterface
 {
     use BitBagSortingTrait;
 
-    /** @var array<string, string> */
+    /**
+     * @var array<string, string>
+     */
     private array $sortingOptions = [
         'Name' => 'translation.name',
         'Code' => 'code',
@@ -36,10 +37,7 @@ final class SectionHandler implements QueryTypeHandlerInterface
         $this->buildBitBagSortingParameters($builder, $this->sortingOptions);
     }
 
-    /**
-     * @return SectionInterface[]
-     */
-    public function getValues(Query $query, int $offset = 0, ?int $limit = null): array
+    public function getValues(Query $query, int $offset = 0, ?int $limit = null): iterable
     {
         $queryBuilder = $this->sectionRepository->createListQueryBuilder(
             $this->localeContext->getLocaleCode(),

--- a/lib/Collection/QueryType/Handler/SectionHandler.php
+++ b/lib/Collection/QueryType/Handler/SectionHandler.php
@@ -47,12 +47,13 @@ final class SectionHandler implements QueryTypeHandlerInterface
 
         $paginator = $this->sectionRepository->createFilterPaginator($queryBuilder);
 
-        $limit = $limit ?? PHP_INT_MAX;
+        $limit = $limit === null ? PHP_INT_MAX : max(0, $limit);
+        $offset = max(0, $offset);
 
         $paginator->setMaxPerPage($limit);
         $paginator->setCurrentPage((int) ($offset / $limit) + 1);
 
-        return $paginator->getCurrentPageResults();
+        return $paginator->getAdapter()->getSlice($offset, $limit);
     }
 
     public function getCount(Query $query): int

--- a/lib/Collection/QueryType/Handler/SectionHandler.php
+++ b/lib/Collection/QueryType/Handler/SectionHandler.php
@@ -62,7 +62,7 @@ final class SectionHandler implements QueryTypeHandlerInterface
             $this->localeContext->getLocaleCode(),
         );
 
-        return (int)$queryBuilder
+        return (int) $queryBuilder
             ->select('count(o.id)')
             ->getQuery()
             ->getSingleScalarResult();

--- a/lib/Collection/QueryType/Handler/Traits/BitBagSortingTrait.php
+++ b/lib/Collection/QueryType/Handler/Traits/BitBagSortingTrait.php
@@ -56,13 +56,13 @@ trait BitBagSortingTrait
         $sortDirection = $parameterCollection->getParameter('sort_direction')->getValue();
         $rootAliases = $queryBuilder->getRootAliases();
 
-        if (!in_array('translations', $queryBuilder->getAllAliases(), true)) {
+        if (!in_array('translation', $queryBuilder->getAllAliases(), true)) {
             $join = count($rootAliases) === 0 ? 'translations' : $rootAliases[0] . '.translations';
 
-            $queryBuilder->innerJoin($join, 'translations');
+            $queryBuilder->innerJoin($join, 'translation');
         }
 
-        if (!str_starts_with($sortField, 'translations.') && count($rootAliases) !== 0) {
+        if (!str_starts_with($sortField, 'translation.') && count($rootAliases) !== 0) {
             $sortField = $rootAliases[0] . '.' . $sortField;
         }
 

--- a/lib/ContentBrowser/Backend/BlockBackend.php
+++ b/lib/ContentBrowser/Backend/BlockBackend.php
@@ -67,11 +67,14 @@ final class BlockBackend implements BackendInterface
             $this->localeContext->getLocaleCode(),
         );
 
+        $limit = max(0, $limit);
+        $offset = max(0, $offset);
+
         $paginator->setMaxPerPage($limit);
         $paginator->setCurrentPage((int) ($offset / $limit) + 1);
 
         return $this->buildItems(
-            $paginator->getCurrentPageResults(),
+            $paginator->getAdapter()->getSlice($offset, $limit),
         );
     }
 

--- a/lib/ContentBrowser/Backend/BlockBackend.php
+++ b/lib/ContentBrowser/Backend/BlockBackend.php
@@ -16,6 +16,7 @@ use Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Block\Item;
 use Netgen\Layouts\Sylius\BitBag\Repository\BlockRepositoryInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 
+use function max;
 use function sprintf;
 
 final class BlockBackend implements BackendInterface

--- a/lib/ContentBrowser/Backend/FrequentlyAskedQuestionBackend.php
+++ b/lib/ContentBrowser/Backend/FrequentlyAskedQuestionBackend.php
@@ -16,6 +16,7 @@ use Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\FrequentlyAskedQuestion\Ite
 use Netgen\Layouts\Sylius\BitBag\Repository\FrequentlyAskedQuestionRepositoryInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 
+use function max;
 use function sprintf;
 
 final class FrequentlyAskedQuestionBackend implements BackendInterface

--- a/lib/ContentBrowser/Backend/FrequentlyAskedQuestionBackend.php
+++ b/lib/ContentBrowser/Backend/FrequentlyAskedQuestionBackend.php
@@ -67,12 +67,13 @@ final class FrequentlyAskedQuestionBackend implements BackendInterface
             $this->localeContext->getLocaleCode(),
         );
 
+        $limit = max(0, $limit);
+        $offset = max(0, $offset);
+
         $paginator->setMaxPerPage($limit);
         $paginator->setCurrentPage((int) ($offset / $limit) + 1);
 
-        return $this->buildItems(
-            $paginator->getCurrentPageResults(),
-        );
+        return $this->buildItems($paginator->getAdapter()->getSlice($offset, $limit));
     }
 
     public function getSubItemsCount(LocationInterface $location): int

--- a/lib/ContentBrowser/Backend/MediaBackend.php
+++ b/lib/ContentBrowser/Backend/MediaBackend.php
@@ -16,6 +16,7 @@ use Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Media\Item;
 use Netgen\Layouts\Sylius\BitBag\Repository\MediaRepositoryInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 
+use function max;
 use function sprintf;
 
 final class MediaBackend implements BackendInterface

--- a/lib/ContentBrowser/Backend/MediaBackend.php
+++ b/lib/ContentBrowser/Backend/MediaBackend.php
@@ -67,11 +67,14 @@ final class MediaBackend implements BackendInterface
             $this->localeContext->getLocaleCode(),
         );
 
+        $limit = max(0, $limit);
+        $offset = max(0, $offset);
+
         $paginator->setMaxPerPage($limit);
         $paginator->setCurrentPage((int) ($offset / $limit) + 1);
 
         return $this->buildItems(
-            $paginator->getCurrentPageResults(),
+            $paginator->getAdapter()->getSlice($offset, $limit),
         );
     }
 

--- a/lib/ContentBrowser/Backend/PageBackend.php
+++ b/lib/ContentBrowser/Backend/PageBackend.php
@@ -16,6 +16,7 @@ use Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Page\Item;
 use Netgen\Layouts\Sylius\BitBag\Repository\PageRepositoryInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 
+use function max;
 use function sprintf;
 
 final class PageBackend implements BackendInterface

--- a/lib/ContentBrowser/Backend/PageBackend.php
+++ b/lib/ContentBrowser/Backend/PageBackend.php
@@ -67,11 +67,14 @@ final class PageBackend implements BackendInterface
             $this->localeContext->getLocaleCode(),
         );
 
+        $limit = max(0, $limit);
+        $offset = max(0, $offset);
+
         $paginator->setMaxPerPage($limit);
         $paginator->setCurrentPage((int) ($offset / $limit) + 1);
 
         return $this->buildItems(
-            $paginator->getCurrentPageResults(),
+            $paginator->getAdapter()->getSlice($offset, $limit),
         );
     }
 

--- a/lib/ContentBrowser/Backend/SectionBackend.php
+++ b/lib/ContentBrowser/Backend/SectionBackend.php
@@ -16,6 +16,7 @@ use Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Section\Item;
 use Netgen\Layouts\Sylius\BitBag\Repository\SectionRepositoryInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 
+use function max;
 use function sprintf;
 
 final class SectionBackend implements BackendInterface

--- a/lib/ContentBrowser/Backend/SectionBackend.php
+++ b/lib/ContentBrowser/Backend/SectionBackend.php
@@ -67,11 +67,14 @@ final class SectionBackend implements BackendInterface
             $this->localeContext->getLocaleCode(),
         );
 
+        $limit = max(0, $limit);
+        $offset = max(0, $offset);
+
         $paginator->setMaxPerPage($limit);
         $paginator->setCurrentPage((int) ($offset / $limit) + 1);
 
         return $this->buildItems(
-            $paginator->getCurrentPageResults(),
+            $paginator->getAdapter()->getSlice($offset, $limit),
         );
     }
 

--- a/lib/Item/ColumnProvider/Block/Code.php
+++ b/lib/Item/ColumnProvider/Block/Code.php
@@ -10,7 +10,7 @@ use Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Block\BlockInterface;
 
 final class Code implements ColumnValueProviderInterface
 {
-    public function getValue(Iteminterface $item): ?string
+    public function getValue(ItemInterface $item): ?string
     {
         if (!$item instanceof BlockInterface) {
             return null;

--- a/lib/Item/ColumnProvider/FrequentlyAskedQuestion/Code.php
+++ b/lib/Item/ColumnProvider/FrequentlyAskedQuestion/Code.php
@@ -10,7 +10,7 @@ use Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\FrequentlyAskedQuestion\Fre
 
 final class Code implements ColumnValueProviderInterface
 {
-    public function getValue(Iteminterface $item): ?string
+    public function getValue(ItemInterface $item): ?string
     {
         if (!$item instanceof FrequentlyAskedQuestionInterface) {
             return null;

--- a/lib/Item/ColumnProvider/Media/Code.php
+++ b/lib/Item/ColumnProvider/Media/Code.php
@@ -10,7 +10,7 @@ use Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Media\MediaInterface;
 
 final class Code implements ColumnValueProviderInterface
 {
-    public function getValue(Iteminterface $item): ?string
+    public function getValue(ItemInterface $item): ?string
     {
         if (!$item instanceof MediaInterface) {
             return null;

--- a/lib/Item/ColumnProvider/Media/MimeType.php
+++ b/lib/Item/ColumnProvider/Media/MimeType.php
@@ -10,7 +10,7 @@ use Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Media\MediaInterface;
 
 final class MimeType implements ColumnValueProviderInterface
 {
-    public function getValue(Iteminterface $item): ?string
+    public function getValue(ItemInterface $item): ?string
     {
         if (!$item instanceof MediaInterface) {
             return null;

--- a/lib/Item/ColumnProvider/Media/Type.php
+++ b/lib/Item/ColumnProvider/Media/Type.php
@@ -10,7 +10,7 @@ use Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Media\MediaInterface;
 
 final class Type implements ColumnValueProviderInterface
 {
-    public function getValue(Iteminterface $item): ?string
+    public function getValue(ItemInterface $item): ?string
     {
         if (!$item instanceof MediaInterface) {
             return null;

--- a/lib/Item/ColumnProvider/Page/Code.php
+++ b/lib/Item/ColumnProvider/Page/Code.php
@@ -10,7 +10,7 @@ use Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Page\PageInterface;
 
 final class Code implements ColumnValueProviderInterface
 {
-    public function getValue(Iteminterface $item): ?string
+    public function getValue(ItemInterface $item): ?string
     {
         if (!$item instanceof PageInterface) {
             return null;

--- a/lib/Item/ColumnProvider/Page/Slug.php
+++ b/lib/Item/ColumnProvider/Page/Slug.php
@@ -10,7 +10,7 @@ use Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Page\PageInterface;
 
 final class Slug implements ColumnValueProviderInterface
 {
-    public function getValue(Iteminterface $item): ?string
+    public function getValue(ItemInterface $item): ?string
     {
         if (!$item instanceof PageInterface) {
             return null;

--- a/lib/Item/ColumnProvider/Section/Code.php
+++ b/lib/Item/ColumnProvider/Section/Code.php
@@ -10,7 +10,7 @@ use Netgen\Layouts\Sylius\BitBag\ContentBrowser\Item\Section\SectionInterface;
 
 final class Code implements ColumnValueProviderInterface
 {
-    public function getValue(Iteminterface $item): ?string
+    public function getValue(ItemInterface $item): ?string
     {
         if (!$item instanceof SectionInterface) {
             return null;

--- a/lib/Repository/BlockRepository.php
+++ b/lib/Repository/BlockRepository.php
@@ -17,11 +17,6 @@ final class BlockRepository extends BaseBlockRepository implements BlockReposito
         return $this->getPaginator($queryBuilder);
     }
 
-    public function createFilterPaginator(QueryBuilder $queryBuilder): PagerfantaInterface
-    {
-        return $this->getPaginator($queryBuilder);
-    }
-
     public function createSearchPaginator(string $searchText, string $localeCode): PagerfantaInterface
     {
         $queryBuilder = $this->createListQueryBuilder($localeCode);

--- a/lib/Repository/BlockRepository.php
+++ b/lib/Repository/BlockRepository.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Netgen\Layouts\Sylius\BitBag\Repository;
 
 use BitBag\SyliusCmsPlugin\Repository\BlockRepository as BaseBlockRepository;
-use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\PagerfantaInterface;
 
 final class BlockRepository extends BaseBlockRepository implements BlockRepositoryInterface

--- a/lib/Repository/BlockRepositoryInterface.php
+++ b/lib/Repository/BlockRepositoryInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Netgen\Layouts\Sylius\BitBag\Repository;
 
 use BitBag\SyliusCmsPlugin\Repository\BlockRepositoryInterface as BaseBlockRepositoryInterface;
-use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\PagerfantaInterface;
 
 interface BlockRepositoryInterface extends BaseBlockRepositoryInterface

--- a/lib/Repository/BlockRepositoryInterface.php
+++ b/lib/Repository/BlockRepositoryInterface.php
@@ -18,13 +18,6 @@ interface BlockRepositoryInterface extends BaseBlockRepositoryInterface
     public function createListPaginator(string $localeCode): PagerfantaInterface;
 
     /**
-     * Creates a paginator which is used to filter blocks.
-     *
-     * @return \Pagerfanta\PagerfantaInterface<\BitBag\SyliusCmsPlugin\Entity\Block>
-     */
-    public function createFilterPaginator(QueryBuilder $queryBuilder): PagerfantaInterface;
-
-    /**
      * Creates a paginator which is used to search for blocks.
      *
      * @return \Pagerfanta\PagerfantaInterface<\BitBag\SyliusCmsPlugin\Entity\Block>

--- a/lib/Repository/FrequentlyAskedQuestionRepository.php
+++ b/lib/Repository/FrequentlyAskedQuestionRepository.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Netgen\Layouts\Sylius\BitBag\Repository;
 
 use BitBag\SyliusCmsPlugin\Repository\FrequentlyAskedQuestionRepository as BaseFrequentlyAskedQuestionRepository;
-use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\PagerfantaInterface;
 
 final class FrequentlyAskedQuestionRepository extends BaseFrequentlyAskedQuestionRepository implements FrequentlyAskedQuestionRepositoryInterface

--- a/lib/Repository/FrequentlyAskedQuestionRepository.php
+++ b/lib/Repository/FrequentlyAskedQuestionRepository.php
@@ -17,11 +17,6 @@ final class FrequentlyAskedQuestionRepository extends BaseFrequentlyAskedQuestio
         return $this->getPaginator($queryBuilder);
     }
 
-    public function createFilterPaginator(QueryBuilder $queryBuilder): PagerfantaInterface
-    {
-        return $this->getPaginator($queryBuilder);
-    }
-
     public function createSearchPaginator(string $searchText, string $localeCode): PagerfantaInterface
     {
         $queryBuilder = $this->createListQueryBuilder($localeCode);

--- a/lib/Repository/FrequentlyAskedQuestionRepositoryInterface.php
+++ b/lib/Repository/FrequentlyAskedQuestionRepositoryInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Netgen\Layouts\Sylius\BitBag\Repository;
 
 use BitBag\SyliusCmsPlugin\Repository\FrequentlyAskedQuestionRepositoryInterface as BaseFrequentlyAskedQuestionRepositoryInterface;
-use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\PagerfantaInterface;
 
 interface FrequentlyAskedQuestionRepositoryInterface extends BaseFrequentlyAskedQuestionRepositoryInterface

--- a/lib/Repository/FrequentlyAskedQuestionRepositoryInterface.php
+++ b/lib/Repository/FrequentlyAskedQuestionRepositoryInterface.php
@@ -18,13 +18,6 @@ interface FrequentlyAskedQuestionRepositoryInterface extends BaseFrequentlyAsked
     public function createListPaginator(string $localeCode): PagerfantaInterface;
 
     /**
-     * Creates a paginator which is used to filter frequently asked questions.
-     *
-     * @return \Pagerfanta\PagerfantaInterface<\BitBag\SyliusCmsPlugin\Entity\FrequentlyAskedQuestion>
-     */
-    public function createFilterPaginator(QueryBuilder $queryBuilder): PagerfantaInterface;
-
-    /**
      * Creates a paginator which is used to search for frequently asked questions.
      *
      * @return \Pagerfanta\PagerfantaInterface<\BitBag\SyliusCmsPlugin\Entity\FrequentlyAskedQuestion>

--- a/lib/Repository/MediaRepository.php
+++ b/lib/Repository/MediaRepository.php
@@ -17,11 +17,6 @@ final class MediaRepository extends BaseMediaRepository implements MediaReposito
         return $this->getPaginator($queryBuilder);
     }
 
-    public function createFilterPaginator(QueryBuilder $queryBuilder): PagerfantaInterface
-    {
-        return $this->getPaginator($queryBuilder);
-    }
-
     public function createSearchPaginator(string $searchText, string $localeCode): PagerfantaInterface
     {
         $queryBuilder = $this->createListQueryBuilder($localeCode);

--- a/lib/Repository/MediaRepository.php
+++ b/lib/Repository/MediaRepository.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Netgen\Layouts\Sylius\BitBag\Repository;
 
 use BitBag\SyliusCmsPlugin\Repository\MediaRepository as BaseMediaRepository;
-use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\PagerfantaInterface;
 
 final class MediaRepository extends BaseMediaRepository implements MediaRepositoryInterface

--- a/lib/Repository/MediaRepositoryInterface.php
+++ b/lib/Repository/MediaRepositoryInterface.php
@@ -18,13 +18,6 @@ interface MediaRepositoryInterface extends BaseMediaRepositoryInterface
     public function createListPaginator(string $localeCode): PagerfantaInterface;
 
     /**
-     * Creates a paginator which is used to filter media.
-     *
-     * @return \Pagerfanta\PagerfantaInterface<\BitBag\SyliusCmsPlugin\Entity\Media>
-     */
-    public function createFilterPaginator(QueryBuilder $queryBuilder): PagerfantaInterface;
-
-    /**
      * Creates a paginator which is used to search for medias.
      *
      * @return \Pagerfanta\PagerfantaInterface<\BitBag\SyliusCmsPlugin\Entity\Media>

--- a/lib/Repository/MediaRepositoryInterface.php
+++ b/lib/Repository/MediaRepositoryInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Netgen\Layouts\Sylius\BitBag\Repository;
 
 use BitBag\SyliusCmsPlugin\Repository\MediaRepositoryInterface as BaseMediaRepositoryInterface;
-use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\PagerfantaInterface;
 
 interface MediaRepositoryInterface extends BaseMediaRepositoryInterface

--- a/lib/Repository/PageRepository.php
+++ b/lib/Repository/PageRepository.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Netgen\Layouts\Sylius\BitBag\Repository;
 
 use BitBag\SyliusCmsPlugin\Repository\PageRepository as BasePageRepository;
-use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\PagerfantaInterface;
 
 final class PageRepository extends BasePageRepository implements PageRepositoryInterface

--- a/lib/Repository/PageRepository.php
+++ b/lib/Repository/PageRepository.php
@@ -17,11 +17,6 @@ final class PageRepository extends BasePageRepository implements PageRepositoryI
         return $this->getPaginator($queryBuilder);
     }
 
-    public function createFilterPaginator(QueryBuilder $queryBuilder): PagerfantaInterface
-    {
-        return $this->getPaginator($queryBuilder);
-    }
-
     public function createSearchPaginator(string $searchText, string $localeCode): PagerfantaInterface
     {
         $queryBuilder = $this->createListQueryBuilder($localeCode);

--- a/lib/Repository/PageRepositoryInterface.php
+++ b/lib/Repository/PageRepositoryInterface.php
@@ -18,13 +18,6 @@ interface PageRepositoryInterface extends BasePageRepositoryInterface
     public function createListPaginator(string $localeCode): PagerfantaInterface;
 
     /**
-     * Creates a paginator which is used to filter pages.
-     *
-     * @return \Pagerfanta\PagerfantaInterface<\BitBag\SyliusCmsPlugin\Entity\Page>
-     */
-    public function createFilterPaginator(QueryBuilder $queryBuilder): PagerfantaInterface;
-
-    /**
      * Creates a paginator which is used to search for pages.
      *
      * @return \Pagerfanta\PagerfantaInterface<\BitBag\SyliusCmsPlugin\Entity\Page>

--- a/lib/Repository/PageRepositoryInterface.php
+++ b/lib/Repository/PageRepositoryInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Netgen\Layouts\Sylius\BitBag\Repository;
 
 use BitBag\SyliusCmsPlugin\Repository\PageRepositoryInterface as BasePageRepositoryInterface;
-use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\PagerfantaInterface;
 
 interface PageRepositoryInterface extends BasePageRepositoryInterface

--- a/lib/Repository/SectionRepository.php
+++ b/lib/Repository/SectionRepository.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Netgen\Layouts\Sylius\BitBag\Repository;
 
 use BitBag\SyliusCmsPlugin\Repository\SectionRepository as BaseSectionRepository;
-use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\PagerfantaInterface;
 
 final class SectionRepository extends BaseSectionRepository implements SectionRepositoryInterface

--- a/lib/Repository/SectionRepository.php
+++ b/lib/Repository/SectionRepository.php
@@ -17,11 +17,6 @@ final class SectionRepository extends BaseSectionRepository implements SectionRe
         return $this->getPaginator($queryBuilder);
     }
 
-    public function createFilterPaginator(QueryBuilder $queryBuilder): PagerfantaInterface
-    {
-        return $this->getPaginator($queryBuilder);
-    }
-
     public function createSearchPaginator(string $searchText, string $localeCode): PagerfantaInterface
     {
         $queryBuilder = $this->createListQueryBuilder($localeCode);

--- a/lib/Repository/SectionRepositoryInterface.php
+++ b/lib/Repository/SectionRepositoryInterface.php
@@ -18,13 +18,6 @@ interface SectionRepositoryInterface extends BaseSectionRepositoryInterface
     public function createListPaginator(string $localeCode): PagerfantaInterface;
 
     /**
-     * Creates a paginator which is used to filter sections.
-     *
-     * @return \Pagerfanta\PagerfantaInterface<\BitBag\SyliusCmsPlugin\Entity\Section>
-     */
-    public function createFilterPaginator(QueryBuilder $queryBuilder): PagerfantaInterface;
-
-    /**
      * Creates a paginator which is used to search for sections.
      *
      * @return \Pagerfanta\PagerfantaInterface<\BitBag\SyliusCmsPlugin\Entity\Section>

--- a/lib/Repository/SectionRepositoryInterface.php
+++ b/lib/Repository/SectionRepositoryInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Netgen\Layouts\Sylius\BitBag\Repository;
 
 use BitBag\SyliusCmsPlugin\Repository\SectionRepositoryInterface as BaseSectionRepositoryInterface;
-use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\PagerfantaInterface;
 
 interface SectionRepositoryInterface extends BaseSectionRepositoryInterface

--- a/psalm.xml
+++ b/psalm.xml
@@ -16,6 +16,18 @@
     <issueHandlers>
         <!-- Doctrine -->
 
+        <InvalidReturnType>
+            <errorLevel type="suppress">
+                <directory name="lib/Collection/QueryType/Handler" />
+            </errorLevel>
+        </InvalidReturnType>
+
+        <InvalidReturnStatement>
+            <errorLevel type="suppress">
+                <directory name="lib/Collection/QueryType/Handler" />
+            </errorLevel>
+        </InvalidReturnStatement>
+
         <DeprecatedConstant>
             <errorLevel type="suppress">
                 <file name="lib/Layout/Resolver/TargetHandler/Doctrine/SectionPage.php" />


### PR DESCRIPTION
content-browser-sylius uses Pagerfanta since there are only Backends, but layouts-sylius use result from Doctrine Query Builder since there are only QueryHandlers. layouts-sylius-bitbag is a merge between the two - having both QueryHandlers and Backends. I have decided to use getAdapter method because of its simplicity. In versions from 3.2.0 to 3.6.2 it says that the method getAdapter will be deprecated, but the deprecation message was removed in version 3.7.0, current version is 4.2.0 and the getAdapter method still exists without any deprecation messages. getSlice method has the same effect as creating a new query with groupBy(entity.id)->setFirstResult(x)->setMaxResults(y) (groupBy is necessary because of the multiple joins happening across the query). So instead of creating new queries and updating a lot of code for the same effect seemed dubious.